### PR TITLE
feat: Add approve job option for circling back

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,9 +10,13 @@ filters: &filters
 
 parameters:
   test:
-    type: boolean
-    default: false
+    type: string
+    default: ""
     description: "Whether this is test pipeline."
+  circleback_workflow_id:
+    type: string
+    default: ""
+    description: "The parameter that contains the CircleCI workflow ID."
 
 jobs:
   success:
@@ -27,7 +31,7 @@ jobs:
 workflows:
   lint-pack:
     when:
-      equal: [false, << pipeline.parameters.test >>]
+      equal: ["", << pipeline.parameters.test >>]
     jobs:
       - orb-tools/lint:
           filters: *filters
@@ -44,9 +48,27 @@ workflows:
           orb_name: circleback
           requires: [orb-tools/lint, orb-tools/pack, orb-tools/review, shellcheck/check]
           filters: *filters
-  test:
+
+  test_wait:
     when:
-      equal: [true, << pipeline.parameters.test >>]
+      equal: ["wait", << pipeline.parameters.test >>]
     jobs:
       - success:
           filters: *filters
+
+  test-approval:
+    when:
+      equal: ["approve", << pipeline.parameters.test >>]
+    jobs:
+      - orb-tools/pack:
+          filters: *filters
+      - orb-tools/continue:
+          config_path: .circleci/test-approval.yml
+          pipeline_number: << pipeline.number >>
+          vcs_type: << pipeline.project.type >>
+          orb_name: circleback
+          requires: [orb-tools/pack]
+          filters: *filters
+
+
+

--- a/.circleci/test-approval.yml
+++ b/.circleci/test-approval.yml
@@ -1,0 +1,25 @@
+version: 2.1
+orbs:
+  # Your orb will be automatically injected here during the pipeline.
+  # Reference your orb's jobs and commands below as they will exist when built.
+  orb-tools: circleci/orb-tools@12.0
+  # The orb definition is intentionally not included here. It will be injected into the pipeline.
+  circleback: {}
+
+parameters:
+  test:
+    type: string
+    default: ""
+    description: "Whether this is test pipeline."
+  circleback_workflow_id:
+    type: string
+    default: ""
+    description: "The parameter that contains the CircleCI workflow ID."
+
+workflows:
+  approve_test_job:
+    jobs:
+      - circleback/approve:
+          project: github/justindalton/circleback-orb
+          workflow_id: << pipeline.parameters.circleback_workflow_id >>
+          approval_job: approval-test

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -33,11 +33,18 @@ jobs:
       - checkout
       # Run your orb's commands to validate them.
       - circleback/trigger:
-          project: github/justincdalton/circleback-orb
-          parameters: '{ "test": true }'
+          branch: << pipeline.git.branch >>
+          project: github/justindalton/circleback-orb
+          parameters: '{ "test": "wait" }'
       - circleback/check_status:
-          project: github/justincdalton/circleback-orb
+          project: github/justindalton/circleback-orb
           poll_interval: 1
+      - circleback/trigger:
+          branch: << pipeline.git.branch >>
+          project: github/justindalton/circleback-orb
+          parameters: '{ "test": "approve" }'
+          include_workflow_id: true
+
 workflows:
   test-deploy:
     jobs:
@@ -45,16 +52,22 @@ workflows:
       # Test your orb's commands in a custom job and test your orb's jobs directly as a part of this workflow.
       - command-test:
           filters: *filters
+      - approval-test:
+          type: approval
+          filters: *filters
+          requires:
+            - command-test
       # The orb must be re-packed for publishing, and saved to the workspace.
       - orb-tools/pack:
           filters: *release-filters
       - orb-tools/publish:
-          orb_name: justincdalton/circleback
+          orb_name: justindalton/circleback
           vcs_type: << pipeline.project.type >>
           pub_type: production
           # Ensure this job requires all test jobs and the pack job.
           requires:
             - command-test
+            - approval-test
             - orb-tools/pack
           context: orb-publishing
           filters: *release-filters

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Circleback Orb
 
 
-[![CircleCI Build Status](https://circleci.com/gh/justincdalton/circleback-orb.svg?style=shield "CircleCI Build Status")](https://circleci.com/gh/justincdalton/circleback-orb) [![CircleCI Orb Version](https://badges.circleci.com/orbs/justincdalton/circleback.svg)](https://circleci.com/developer/orbs/orb/justincdalton/circleback) [![GitHub License](https://img.shields.io/badge/license-MIT-lightgrey.svg)](https://raw.githubusercontent.com/justincdalton/circleback-orb/master/LICENSE) [![CircleCI Community](https://img.shields.io/badge/community-CircleCI%20Discuss-343434.svg)](https://discuss.circleci.com/c/ecosystem/orbs)
+[![CircleCI Build Status](https://circleci.com/gh/justindalton/circleback-orb.svg?style=shield "CircleCI Build Status")](https://circleci.com/gh/justindalton/circleback-orb) [![CircleCI Orb Version](https://badges.circleci.com/orbs/justindalton/circleback.svg)](https://circleci.com/developer/orbs/orb/justindalton/circleback) [![GitHub License](https://img.shields.io/badge/license-MIT-lightgrey.svg)](https://raw.githubusercontent.com/justindalton/circleback-orb/master/LICENSE) [![CircleCI Community](https://img.shields.io/badge/community-CircleCI%20Discuss-343434.svg)](https://discuss.circleci.com/c/ecosystem/orbs)
 
 
 This orb is a helper when orchestrating pipelines with the [circleback pattern](https://circleci.com/blog/pipeline-orchestration-circleback/). It has commands for triggering another CircleCI pipeline and checking the status of the triggered pipeline.
@@ -12,20 +12,20 @@ This is useful when multiple projects in separate repositories are interdependen
 
 ## Resources
 
-[CircleCI Orb Registry Page](https://circleci.com/developer/orbs/orb/justincdalton/circleback) - The official registry page of this orb for all versions, executors, commands, and jobs described.
+[CircleCI Orb Registry Page](https://circleci.com/developer/orbs/orb/justindalton/circleback) - The official registry page of this orb for all versions, executors, commands, and jobs described.
 
 [CircleCI Orb Docs](https://circleci.com/docs/orb-intro/#section=configuration) - Docs for using, creating, and publishing CircleCI Orbs.
 
 ### How to Contribute
 
-We welcome [issues](https://github.com/justincdalton/circleback-orb/issues) to and [pull requests](https://github.com/justincdalton/circleback-orb/pulls) against this repository!
+We welcome [issues](https://github.com/justindalton/circleback-orb/issues) to and [pull requests](https://github.com/justindalton/circleback-orb/pulls) against this repository!
 
 ### How to Publish An Update
 1. Merge pull requests with desired changes to the main branch.
     - For the best experience, squash-and-merge and use [Conventional Commit Messages](https://conventionalcommits.org/).
 2. Find the current version of the orb.
-    - You can run `circleci orb info justincdalton/circleback | grep "Latest"` to see the current version.
-3. Create a [new Release](https://github.com/justincdalton/circleback-orb/releases/new) on GitHub.
+    - You can run `circleci orb info justindalton/circleback | grep "Latest"` to see the current version.
+3. Create a [new Release](https://github.com/justindalton/circleback-orb/releases/new) on GitHub.
     - Click "Choose a tag" and _create_ a new [semantically versioned](http://semver.org/) tag. (ex: v1.0.0)
       - We will have an opportunity to change this before we publish if needed after the next step.
 4.  Click _"+ Auto-generate release notes"_.

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -7,8 +7,8 @@ description: >
 
 # This information will be displayed in the orb registry and is not mandatory.
 display:
-  home_url: "https://github.com/justincdalton/circleback-orb"
-  source_url: "https://github.com/justincdalton/circleback-orb"
+  home_url: "https://github.com/justindalton/circleback-orb"
+  source_url: "https://github.com/justindalton/circleback-orb"
 
 # If your orb requires other orbs, you can import them like this. Otherwise remove the "orbs" stanza.
 # orbs:

--- a/src/commands/approve.yml
+++ b/src/commands/approve.yml
@@ -1,0 +1,27 @@
+description: >
+  This command triggers a pipeline in a separate project via the CircleCI API.
+
+parameters:
+  circleci_api_key:
+    type: env_var_name
+    default: CIRCLECI_API_KEY
+    description: "The name of the environment variable that contains the CircleCI API key."
+  project:
+    type: string
+    description: "The name of the project with the approval job."
+  workflow_id:
+    type: string
+    default: ''
+    description: "The workflow ID for the approval job."
+  approval_job:
+    type: string
+    description: "The name of the approval job."
+steps:
+  - run:
+      environment:
+        PARAM_CIRCLECI_API_KEY: <<parameters.circleci_api_key>>
+        PARAM_PROJECT: <<parameters.project>>
+        PARAM_WORKFLOW_ID: <<parameters.workflow_id>>
+        PARAM_APPROVAL_JOB: <<parameters.approval_job>>
+      name: Approve Job
+      command: <<include(scripts/approve.sh)>>

--- a/src/commands/trigger.yml
+++ b/src/commands/trigger.yml
@@ -17,10 +17,10 @@ parameters:
   project:
     type: string
     description: "The name of the project to trigger."
-  workflow_id:
-    type: string
-    default: ''
-    description: "The workflow ID for the current circle workflow."
+  include_workflow_id:
+    type: boolean
+    default: false
+    description: "Whether to include the workflow ID in the pipeline parameters."
 steps:
   - run:
       environment:
@@ -28,7 +28,7 @@ steps:
         PARAM_CIRCLECI_API_KEY: <<parameters.circleci_api_key>>
         PARAM_PARAMETERS: <<parameters.parameters>>
         PARAM_PROJECT: <<parameters.project>>
-        PARAM_WORKFLOW_ID: <<parameters.workflow_id>>
+        PARAM_INCLUDE_WORKFLOW_ID: <<parameters.include_workflow_id>>
       name: Trigger Pipeline
       command: <<include(scripts/trigger.sh)>>
   - persist_to_workspace:

--- a/src/examples/example.yml
+++ b/src/examples/example.yml
@@ -6,17 +6,17 @@ description: >
 usage:
   version: 2.1
   orbs:
-    circlback-orb: justincdalton/circleback@1.0.2
+    circlback-orb: justindalton/circleback@1.0.2
   jobs:
     run-tests:
       executor: circlback/default
       steps:
         - checkout
         - circleback/trigger:
-            project: github/justincdalton/circleback-orb
+            project: github/justindalton/circleback-orb
             parameters: '{ "test": true }'
         - circleback/check_status:
-            project: github/justincdalton/circleback-orb
+            project: github/justindalton/circleback-orb
   workflows:
     trigger-another-pipeline:
       jobs:

--- a/src/jobs/approve.yml
+++ b/src/jobs/approve.yml
@@ -1,0 +1,26 @@
+description: >
+  This job triggers a pipeline in a separate project via the CircleCI API.
+
+executor: default
+
+parameters:
+  circleci_api_key:
+    type: env_var_name
+    default: CIRCLECI_API_KEY
+    description: "The name of the environment variable that contains the CircleCI API key."
+  project:
+    type: string
+    description: "The name of the project with the approval job."
+  workflow_id:
+    type: string
+    description: "The workflow ID for the approval job."
+  approval_job:
+    type: string
+    description: "The name of the approval job."
+steps:
+  - checkout
+  - approve:
+      circleci_api_key: <<parameters.circleci_api_key>>
+      project: <<parameters.project>>
+      workflow_id: <<parameters.workflow_id>>
+      approval_job: <<parameters.approval_job>>

--- a/src/jobs/trigger_and_wait.yml
+++ b/src/jobs/trigger_and_wait.yml
@@ -19,10 +19,6 @@ parameters:
   project:
     type: string
     description: "The name of the project to trigger."
-  workflow_id:
-    type: string
-    default: ''
-    description: "The workflow ID for the current circle workflow."
 steps:
   - checkout
   - trigger:
@@ -30,7 +26,6 @@ steps:
       circleci_api_key: <<parameters.circleci_api_key>>
       parameters: <<parameters.parameters>>
       project: <<parameters.project>>
-      workflow_id: <<parameters.workflow_id>>
   - check_status:
       circleci_api_key: <<parameters.circleci_api_key>>
       poll: true

--- a/src/scripts/trigger.sh
+++ b/src/scripts/trigger.sh
@@ -11,8 +11,8 @@ CIRCLE_TOKEN="${!PARAM_CIRCLECI_API_KEY}"
 PARAMETERS="{}"
 
 # Check if CIRCLE_WORKFLOW_ID is set and add to parameters
-if [ -n "$PARAM_WORKFLOW_ID" ]; then
-  PARAMETERS="{\"circleback_workflow_id\":\"$PARAM_WORKFLOW_ID\"}"
+if [ -n "$PARAM_INCLUDE_WORKFLOW_ID" ]; then
+  PARAMETERS="{\"circleback_workflow_id\":\"$CIRCLE_WORKFLOW_ID\"}"
 fi
 
 # merge PARAM_PARAMETERS into PARAMETERS if it exists


### PR DESCRIPTION
- Adds `approve` command and job
- This can be used for triggering an approval job on the triggering pipeline
- It is an alternative to polling the triggered job status